### PR TITLE
Update Freedestop SDK to version 23.08.23

### DIFF
--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -5,7 +5,7 @@ sources:
   url: gitlab:freedesktop-sdk/freedesktop-sdk.git
   track: release/23.08
   track-tags: True
-  ref: freedesktop-sdk-23.08.21-0-gb74caa1b214da1f15cc278327d7806ebcae726a2
+  ref: freedesktop-sdk-23.08.23-0-g50138310131e28a0fb0c62e7371f289f3b24f369
 - kind: create_custom_fdo_sdk_include_ffmpeg
 
 config:

--- a/elements/plugins/bst-plugin-experimental.bst
+++ b/elements/plugins/bst-plugin-experimental.bst
@@ -1,6 +1,0 @@
-kind: junction
-
-sources:
-- kind: tar
-  url: pypi:26/b1/30ddb1d647d65166bfb80976614592c430017a3c55366afd9a917f702c7a/bst_plugins_experimental-1.100.1.tar.gz
-  ref: f0c71cd2e114c7e5e3df02856558b08a3d6535561a89026308875b1a45746151

--- a/elements/plugins/buildstream-plugins-community.bst
+++ b/elements/plugins/buildstream-plugins-community.bst
@@ -1,0 +1,7 @@
+kind: junction
+
+sources:
+- kind: tar
+  url: pypi:80/e7/e39284fab4c15cbace51dbcb1896529f0f4a3a1a769a204cf24df8d360e8/buildstream_plugins_community-2.0.2.tar.gz
+  ref: 778e8198661bea44944c505923ffd3c44fec24da5f7450cb5ce5b21871a9443c
+

--- a/elements/plugins/buildstream-plugins.bst
+++ b/elements/plugins/buildstream-plugins.bst
@@ -1,6 +1,9 @@
 kind: junction
 
 sources:
-- kind: tar
-  url: pypi:d4/25/b7912ba305e6bd5e4cade588c5ae80e56b7cb70fb7fb9b318a1168223349/buildstream-plugins-2.2.0.tar.gz
-  ref: 9ee14fda3712d086f7ab6c76584fa1e01bc08960ab047a3e8f33247e8c1d68f6
+- kind: git_repo
+  url: github:apache/buildstream-plugins.git
+  track: "*.*.*"
+  exclude:
+  - "*dev*"
+  ref: 2.2.0-0-gdb71610b7ae9884f6d8cbe0d3cc5a1c657c19edb

--- a/project.conf
+++ b/project.conf
@@ -111,7 +111,7 @@ plugins:
   - patch
 
 - origin: junction
-  junction: plugins/bst-plugin-experimental.bst
+  junction: plugins/buildstream-plugins-community.bst
   elements:
   - collect_manifest
   sources:


### PR DESCRIPTION
Also synchonize plugins in use, note that bst-plugin-experimental was rebranded buildstream-plugins-community