### PR TITLE
Update Freedesktop SDK to version 24.08

### DIFF
--- a/elements/components/ffmpeg.bst
+++ b/elements/components/ffmpeg.bst
@@ -36,17 +36,11 @@ variables:
   # Only x264 is disabled in Freedesktop SDK
   obs-missing-encoders: libx264,libx264rgb
 
-  # FFmpeg 7.0 requires more recent Vulkan headers than what Freedesktop SDK 23.08 provides
-  # TODO: Remove once the header is update (e.g. Freedesktop SDK 24.08)
-  fixup-conf-extra: >-
-    --disable-vulkan
-
   conf-extra: >-
     --enable-encoder=%{fdo-encoders},%{obs-missing-encoders}
     --enable-decoder=%{fdo-decoders}
     %{obs-conf-extra}
     %{fdo-conf-extra}
-    %{fixup-conf-extra}
 
 config:
   configure-commands:

--- a/elements/components/libdatachannel.bst
+++ b/elements/components/libdatachannel.bst
@@ -21,5 +21,5 @@ variables:
 sources:
 - kind: git_repo
   url: github:paullouisageneau/libdatachannel.git
-  track: v0.21.0
-  ref: 9d5c46b8f506943727104d766e5dad0693c5a223
+  track: v0.21.1
+  ref: 898bdffe7340134f0891633cc7a6f6d2132c31c3

--- a/elements/components/libvpl.bst
+++ b/elements/components/libvpl.bst
@@ -31,5 +31,5 @@ public:
 sources:
 - kind: git_repo
   url: github:intel/libvpl.git
-  track: v2.12.0
-  ref: 0c13c410095764799afea0cf645bd896378579b8
+  track: v2.14.0
+  ref: 025d43d086a3e663184cb49febe86152bf05409f

--- a/elements/components/vpl-gpu-rt.bst
+++ b/elements/components/vpl-gpu-rt.bst
@@ -23,9 +23,7 @@ public:
 sources:
 - kind: git_repo
   url: github:intel/vpl-gpu-rt.git
-  # VVC support in libva is required since 24.3 and is not available in the version of libva provided by Freedesktop 23.08
-  # TODO: Update to 24.3 or later once libva is updated (e.g. Freedesktop SDK 24.08)
-  track: intel-onevpl-24.2.5
-  ref: e0b981d1bf8ca4f9d346089d530cc149c09e10df
+  track: intel-onevpl-24.3.4
+  ref: fcad0a923c5d7d7483eb993378f7055a1b348241
 - kind: patch
   path: patches/vpl-gpu-rt/010-vpl-gpu-rt-disable-verbose-makefile.patch

--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -3,9 +3,9 @@ kind: junction
 sources:
 - kind: git_tag
   url: gitlab:freedesktop-sdk/freedesktop-sdk.git
-  track: release/23.08
+  track: release/24.08
   track-tags: True
-  ref: freedesktop-sdk-23.08.27-0-g1f8958b9d76635b3e5e60157d9f557dee1b7516e
+  ref: freedesktop-sdk-24.08.10-0-ga0402e153abcd22949934e9dfe39ab69c5784536
 - kind: create_custom_fdo_sdk_include_ffmpeg
 
 config:


### PR DESCRIPTION
Update libdatachannel because of missing header issue and update Intel deps that were blocked because of 23.08.