### PR TITLE
CI: Show BuildStream cache usage and increate Flatpak Qt cache size

### DIFF
--- a/.github/actions/cache-restore/action.yaml
+++ b/.github/actions/cache-restore/action.yaml
@@ -60,6 +60,13 @@ runs:
         key: ${{ inputs.key }}
         restore-keys: ${{ inputs.restore-keys }}
 
+    - name: Show disk usage
+      shell: bash
+      run: |
+        : Show disk usage
+
+        du -hs ${{ inputs.path }}
+
     - name: Setup buildbox-casd Container
       id: container
       shell: bash

--- a/.github/actions/cache-save/action.yaml
+++ b/.github/actions/cache-save/action.yaml
@@ -20,7 +20,17 @@ runs:
 
     - name: Stop buildbox-casd Container
       shell: bash
-      run: podman stop buildbox-casd
+      run: |
+        : Stop buildbox-casd Container
+
+        podman stop buildbox-casd
+
+    - name: Show disk usage
+      shell: bash
+      run: |
+        : Show disk usage
+
+        du -hs ${{ inputs.path }}
 
     - name: Save Cache
       uses: actions/cache/save@v4

--- a/.github/workflows/build-fp-modules.yaml
+++ b/.github/workflows/build-fp-modules.yaml
@@ -30,6 +30,10 @@ on:
         description: Re-upload the cache to avoid automatic eviction
         default: false
         type: boolean
+      max-uncompressed-cache-size:
+        description: Size of the cache uncompressed
+        type: string
+        required: true
 env:
   PROJECT_OPTIONS: target_arch ${{ inputs.arch }}
 jobs:
@@ -59,7 +63,8 @@ jobs:
         id: cache-restore
         uses: ./.github/actions/cache-restore
         with:
-          server-quota-high: 2G
+          server-quota-high: ${{ inputs.max-uncompressed-cache-size }}
+          server-reserved: 10G
           key: ${{ inputs.cache-key-prefix }}${{ inputs.cache-key-hash }}
           restore-keys: |
             ${{ inputs.cache-key-prefix }}
@@ -138,7 +143,8 @@ jobs:
         id: cache-restore
         uses: ./.github/actions/cache-restore
         with:
-          server-quota-high: 2G
+          server-quota-high: ${{ inputs.max-uncompressed-cache-size }}
+          server-reserved: 10G
           key: ${{ needs.pre-build.outputs.cache-key }}
           restore-keys: |
             ${{ inputs.cache-key-prefix }}

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -48,6 +48,7 @@ jobs:
       arch: ${{ matrix.arch }}
       upload-artifacts: ${{ inputs.upload-artifacts }}
       reupload-cache: ${{ inputs.reupload-cache }}
+      max-uncompressed-cache-size: 2G
 
   fp-qt:
     name: Build qt.bst
@@ -65,3 +66,4 @@ jobs:
       arch: ${{ matrix.arch }}
       upload-artifacts: ${{ inputs.upload-artifacts }}
       reupload-cache: ${{ inputs.reupload-cache }}
+      max-uncompressed-cache-size: 4G


### PR DESCRIPTION
Show uncompressed cache usage to compare with set cache settings that are all uncompressed.

Qt x86_64 cache 2G compressed to 1.1 GB
Qt aarch64 is suspected to have a slightly bigger cache which explain that Qt still gets built while generating the module.