### PR TITLE
obs-deps 2025-03-06 sync

### DIFF
--- a/elements/components/asio.bst
+++ b/elements/components/asio.bst
@@ -4,10 +4,10 @@ build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
 
 variables:
-  asio-tag: asio-1-31-0
+  asio-tag: asio-1-32-0
 
 sources:
 - kind: tar
   url: github:chriskohlhoff/asio/archive/refs/tags/%{asio-tag}.tar.gz
   base-dir: "asio-%{asio-tag}/asio"
-  ref: 530540f973498c2d297771af1bc852f69b27509bbb56bc7ac3309c928373286f
+  ref: f1b94b80eeb00bb63a3c8cef5047d4e409df4d8a3fe502305976965827d95672

--- a/elements/components/ffmpeg.bst
+++ b/elements/components/ffmpeg.bst
@@ -58,8 +58,8 @@ public:
 sources:
 - kind: git_repo
   url: github:FFmpeg/FFmpeg.git
-  track: n7.0.2
-  ref: e3a61e91030696348b56361bdf80ea358aef4a19
+  track: n7.1
+  ref: b08d7969c550a804a59511c7b83f2dd8cc0499b8
 - kind: patch
   path: patches/ffmpeg/0001-flvdec-handle-unknown.patch
 - kind: patch

--- a/elements/components/luajit.bst
+++ b/elements/components/luajit.bst
@@ -29,4 +29,4 @@ public:
 sources:
 - kind: git_repo
   url: github:LuaJIT/LuaJIT.git
-  ref: f725e44cda8f359869bf8f92ce71787ddca45618
+  ref: a4f56a459a588ae768801074b46ba0adcfb49eb1

--- a/elements/components/mbedtls.bst
+++ b/elements/components/mbedtls.bst
@@ -7,7 +7,7 @@ depends:
 - freedesktop-sdk.bst:bootstrap-import.bst
 
 variables:
-  mbedtls-version: 3.4.0
+  mbedtls-version: 3.6.2
   cmake-local: >-
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DUSE_SHARED_MBEDTLS_LIBRARY=ON
@@ -15,55 +15,11 @@ variables:
     -DENABLE_TESTING=OFF
     -DENABLE_PROGRAMS=OFF
 
-config:
-  install-commands:
-    (>):
-    - |
-      mkdir -p '%{install-root}%{libdir}/pkgconfig'
-
-      cat <<EOF > '%{install-root}%{libdir}/pkgconfig/mbedcrypto.pc'
-      prefix=%{prefix}
-      exec_prefix=%{exec_prefix}
-      libdir=%{libdir}
-      includedir=%{includedir}
-
-      Name: mbedcrypto
-      Description: lightweight crypto and SSL/TLS library.
-      Version: %{mbedtls-version}
-      Libs: -L\${libdir} -lmbedcrypto
-      Cflags: -I\${includedir}
-      EOF
-
-      cat <<EOF > '%{install-root}%{libdir}/pkgconfig/mbedtls.pc'
-      prefix=%{prefix}
-      exec_prefix=%{exec_prefix}
-      libdir=%{libdir}
-      includedir=%{includedir}
-
-      Name: mbedtls
-      Description: lightweight crypto and SSL/TLS library.
-      Version: %{mbedtls-version}
-      Libs: -L\${libdir} -lmbedtls
-      Cflags: -I\${includedir}
-      Require.private: mbedx509
-      EOF
-
-      cat <<EOF > '%{install-root}%{libdir}/pkgconfig/mbedx509.pc'
-      prefix=%{prefix}
-      exec_prefix=%{exec_prefix}
-      libdir=%{libdir}
-      includedir=%{includedir}
-
-      Name: mbedx509
-      Description: The mbedTLS X.509 library
-      Version: %{mbedtls-version}
-      Libs: -L\${libdir} -lmbedx509
-      Cflags: -I\${includedir}
-      Require.private: mbedcrypto
-      EOF
-
 sources:
-- kind: git_repo
-  url: github:Mbed-TLS/mbedtls.git
-  track: v%{mbedtls-version}
-  ref: 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
+# MbedTLS provide a release tarball that allows to avoid maintaining git submodules
+- kind: tar
+  url:
+    github:Mbed-TLS/mbedtls/releases/download/mbedtls-%{mbedtls-version}/mbedtls-%{mbedtls-version}.tar.bz2
+  ref: 8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca
+- kind: patch
+  path: patches/mbedtls/0001-array-bounds-error-fix.patch

--- a/elements/components/nv-codec.bst
+++ b/elements/components/nv-codec.bst
@@ -11,5 +11,5 @@ variables:
 sources:
 - kind: git_repo
   url: github:ffmpeg/nv-codec-headers.git
-  track: n12.2.72.0
-  ref: c69278340ab1d5559c7d7bf0edf615dc33ddbba7
+  track: n13.0.19.0
+  ref: e844e5b26f46bb77479f063029595293aa8f812d

--- a/elements/components/qt/base.bst
+++ b/elements/components/qt/base.bst
@@ -260,6 +260,6 @@ variables:
 
 sources:
 - kind: tar
-  url:
+  url: 
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtbase-everywhere-src-%{qt-version}.tar.xz
-  ref: 0493fd0b380c4edf8872f011a7f26d245aa4cdd75b349904ef340a22dedf7462
+  ref: 012043ce6d411e6e8a91fdc4e05e6bedcfa10fcb1347d3c33908f7fdd10dfe05

--- a/elements/components/qt/declarative.bst
+++ b/elements/components/qt/declarative.bst
@@ -24,6 +24,6 @@ variables:
 
 sources:
 - kind: tar
-  url:
+  url: 
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtdeclarative-everywhere-src-%{qt-version}.tar.xz
-  ref: 05207b2cfcf2ca74321165e81fc382ca289340d52de74ca2bad4c2b124a792f3
+  ref: 144d876adc8bb55909735143e678d1e24eadcd0a380a0186792d88b731346d56

--- a/elements/components/qt/imageformats.bst
+++ b/elements/components/qt/imageformats.bst
@@ -23,6 +23,6 @@ variables:
 
 sources:
 - kind: tar
-  url:
+  url: 
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtimageformats-everywhere-src-%{qt-version}.tar.xz
-  ref: 3ca5ea60176603ce6ffc1bff59a4dcea139375233ce8e5e86c38f4e84c44627c
+  ref: d2a1bbb84707b8a0aec29227b170be00f04383fbf2361943596d09e7e443c8e1

--- a/elements/components/qt/languageserver.bst
+++ b/elements/components/qt/languageserver.bst
@@ -11,4 +11,4 @@ sources:
 - kind: tar
   url: 
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtlanguageserver-everywhere-src-%{qt-version}.tar.xz
-  ref: 1021b4b9024bd23bef86292f4b6c15cc7db620b6c47be8cb6e539bfae7f6cf8c
+  ref: 9eeb74ac15334c08777548c01e4ede80a4e2d36f1ebcb322423f24f14c2785fb

--- a/elements/components/qt/shadertools.bst
+++ b/elements/components/qt/shadertools.bst
@@ -11,4 +11,4 @@ sources:
 - kind: tar
   url: 
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtshadertools-everywhere-src-%{qt-version}.tar.xz
-  ref: 8c0909d63bb33cb863c0de5a823cd4ad3489858023ab81a7fe84080c3d3ca1e6
+  ref: d1d5f90e8885fc70d63ac55a4ce4d9a2688562033a000bc4aff9320f5f551871

--- a/elements/components/qt/svg.bst
+++ b/elements/components/qt/svg.bst
@@ -9,6 +9,6 @@ depends:
 
 sources:
 - kind: tar
-  url:
+  url: 
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtsvg-everywhere-src-%{qt-version}.tar.xz
-  ref: 4acb1e576eca55e955cf2b0d15c914a200df290e737accd7c1901fa1e33a25c7
+  ref: aa2579f21ca66d19cbcf31d87e9067e07932635d36869c8239d4decd0a9dc1fa

--- a/elements/components/qt/wayland.bst
+++ b/elements/components/qt/wayland.bst
@@ -14,7 +14,6 @@ depends:
   - components/qt/declarative.bst
 
 variables:
-  # TODO: Disable adwaita feature when upgrading Qt
   cmake-local: >-
     -DFEATURE_wayland_client=ON
     -DFEATURE_wayland_server=OFF
@@ -36,4 +35,4 @@ sources:
 - kind: tar
   url:
     qt_archive:%{qt-api-version}/%{qt-version}/submodules/qtwayland-everywhere-src-%{qt-version}.tar.xz
-  ref: a96ecc0fecc05f9e18cfb7806fe5ebd7416be94e8f51ebeca75c80412f66553d
+  ref: 5e46157908295f2bf924462d8c0855b0508ba338ced9e810891fefa295dc9647

--- a/elements/components/srt.bst
+++ b/elements/components/srt.bst
@@ -18,13 +18,13 @@ public:
   bst:
     split-rules:
       exec-blocklist:
-        - "%{bindir}"
-        - "%{bindir}/**"
-        - "%{debugdir}%{bindir}"
-        - "%{debugdir}%{bindir}/**"
+      - "%{bindir}"
+      - "%{bindir}/**"
+      - "%{debugdir}%{bindir}"
+      - "%{debugdir}%{bindir}/**"
 
 sources:
 - kind: git_repo
   url: github:Haivision/srt.git
-  track: v1.5.3
-  ref: 09f35c0f1743e23f514cb41444504a7faeacf89e
+  track: v1.5.4
+  ref: a8c6b65520f814c5bd8f801be48c33ceece7c4a6

--- a/elements/components/svt-av1.bst
+++ b/elements/components/svt-av1.bst
@@ -20,5 +20,5 @@ variables:
 sources:
 - kind: git_repo
   url: gitlab:AOMediaCodec/SVT-AV1.git
-  track: v2.2.1
-  ref: 55a01def732bb9e7016d23cc512384f7a88d6e86
+  track: v2.3.0
+  ref: 6e69def4ec283fe0b71195671245c3b768bebdef

--- a/elements/components/vpl-gpu-rt.bst
+++ b/elements/components/vpl-gpu-rt.bst
@@ -23,7 +23,7 @@ public:
 sources:
 - kind: git_repo
   url: github:intel/vpl-gpu-rt.git
-  track: intel-onevpl-24.3.4
-  ref: fcad0a923c5d7d7483eb993378f7055a1b348241
+  track: intel-onevpl-24.4.4
+  ref: 7277c25ec5362e92d2fa334e2ce356c473ba4778
 - kind: patch
   path: patches/vpl-gpu-rt/010-vpl-gpu-rt-disable-verbose-makefile.patch

--- a/elements/include/qt.yml
+++ b/elements/include/qt.yml
@@ -5,8 +5,8 @@ depends:
 - freedesktop-sdk.bst:bootstrap-import.bst
 
 variables:
-  qt-api-version: "6.6"
-  qt-version: "6.6.3"
+  qt-api-version: "6.8"
+  qt-version: "6.8.2"
 
   qt-bindir: "%{bindir}"
   qt-includedir: "%{includedir}/qt"

--- a/patches/mbedtls/0001-array-bounds-error-fix.patch
+++ b/patches/mbedtls/0001-array-bounds-error-fix.patch
@@ -1,0 +1,27 @@
+diff --git a/library/common.h b/library/common.h
+index 3936ffdfe..d8c407319 100644
+--- a/library/common.h
++++ b/library/common.h
+@@ -192,21 +192,21 @@ static inline void mbedtls_xor(unsigned char *r,
+ #if defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)
+ #if defined(MBEDTLS_HAVE_NEON_INTRINSICS) && \
+     (!(defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION < 70300))
+     /* Old GCC versions generate a warning here, so disable the NEON path for these compilers */
+     for (; (i + 16) <= n; i += 16) {
+         uint8x16_t v1 = vld1q_u8(a + i);
+         uint8x16_t v2 = vld1q_u8(b + i);
+         uint8x16_t x = veorq_u8(v1, v2);
+         vst1q_u8(r + i, x);
+     }
+-#if defined(__IAR_SYSTEMS_ICC__)
++#if defined(__IAR_SYSTEMS_ICC__) || defined(MBEDTLS_COMPILER_IS_GCC)
+     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+      * where n is a constant multiple of 16.
+      * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
+      * constant, and is a very small perf regression if n is not a compile-time constant. */
+     if (n % 16 == 0) {
+         return;
+     }
+ #endif
+ #elif defined(MBEDTLS_ARCH_IS_X64) || defined(MBEDTLS_ARCH_IS_ARM64)
+     /* This codepath probably only makes sense on architectures with 64-bit registers */


### PR DESCRIPTION
- Update MbedTLS to version 3.6.2 
  - Custom pkg-config files are removed, lirist is able to build without and this likely also due to Freedesktop SDK 24.08 that got some workaround removed on Meson since 23.08
- Update nv-codec-headers to version 13.0.19.0
- Update libsrt to version 1.5.4
- Update svt-av1 to version 2.3.0
- Update FFmpeg to version 7.1
- Update LuaJIT to version 2.1 a4f56a459
- Update vpl-gpu-rt to version 24.4.4
  - VPL was already update to version 2.14.0
- Update Asio to version 1.32.0
- Update Qt to version 6.8.2