### PR TITLE
Add ECM to Flatpak deps

### DIFF
--- a/elements/components/extra-cmake-modules.bst
+++ b/elements/components/extra-cmake-modules.bst
@@ -1,0 +1,17 @@
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+
+variables:
+  cmake-local: >-
+    -DBUILD_TESTING:BOOL=OFF
+    -DBUILD_HTML_DOCS:BOOL=OFF
+    -DBUILD_MAN_DOCS:BOOL=OFF
+    -DBUILD_QTHELP_DOCS:BOOL=OFF
+
+sources:
+- kind: git_repo
+  url: github:KDE/extra-cmake-modules.git
+  track: v6.13.0
+  ref: 1f820dc98d0a520c175433bcbb0098327d82aac6

--- a/elements/deps.bst
+++ b/elements/deps.bst
@@ -3,6 +3,7 @@ description: Stack of OBS Studio non-Qt dependencies
 
 depends:
 - components/asio.bst
+- components/extra-cmake-modules.bst
 - components/ffmpeg.bst
 - components/jansson.bst
 - components/libajantv2.bst


### PR DESCRIPTION
ECM was in the Freedesktop SDK project but not shipped as a part of the Flatpak SDK.